### PR TITLE
Make use of custom kustomize transformer to append suffix to Job name

### DIFF
--- a/k8s/jobNameSuffix.yaml
+++ b/k8s/jobNameSuffix.yaml
@@ -1,0 +1,8 @@
+apiVersion: internal
+kind: JobNameSuffix
+metadata:
+  name: job-name-suffix
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: job_name_suffix.sh

--- a/k8s/job_name_suffix.sh
+++ b/k8s/job_name_suffix.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+yq "(.items[] | select(.kind == \"Job\") | .metadata.name) += \"-$(git rev-parse --short HEAD)\"" < /dev/stdin

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -12,6 +12,9 @@ images:
     newName: sbwise/k8s-db-app-init
     newTag: "1.0.3"
 
+transformers:
+  - jobNameSuffix.yaml
+
 resources:
   - configmap.yaml
   - deployment.yaml


### PR DESCRIPTION
Note, you have to make sure that `PATH` contains the executable in addition to adding the additional enable flags to kustomize in order to have it execute this custom kustomize plugin.  For example:

```
PATH=$PATH:`pwd` kustomize build --enable-alpha-plugins --enable-exec .
```